### PR TITLE
typo and more debug log

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ local pos_ttl = 20000  -- in ms
 local neg_ttl = 10000  -- in ms
 
 local my_shdict_set, my_shdict_get
-                  = meta_shdict.gen_shdict_methods{
+                  = shdict_simple.gen_shdict_methods{
                        debug_logger = dlog,
                        error_logger = error_log,
                        positive_ttl = pos_ttl,

--- a/lib/resty/shdict/simple.lua
+++ b/lib/resty/shdict/simple.lua
@@ -39,6 +39,10 @@ function _M.gen_shdict_methods (opts)
         local ok, err = shdict:safe_set(key, value, ttl)
         if not ok then
             if err == "no memory" then
+                if DEBUG then
+                    dlog(ctx, 'shdict ', dict_name,
+                            ' out of memory, and now try to set by force')
+                end
                 -- with force:
                 ok, err = shdict:set(key, value, ttl)
             end


### PR DESCRIPTION
I have no idea why we don't call `shdict:set` directly, and I think a debug message is valuable here.

Any thoughts?  
